### PR TITLE
Great plugin. Further Improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Changelog
-
+* 1.0.4	Added preload to tracker cache. Added settings option for the modification of the tracking code
 * 1.0.3 Fixed a bug where table prefix, when defined, was being ignored
 * 1.0.2 Plugin name change & re-publish on marketplace
 * 1.0.1 Updates to plugin description

--- a/SiteUrlTrackingID.php
+++ b/SiteUrlTrackingID.php
@@ -17,20 +17,20 @@ class SiteUrlTrackingID extends \Piwik\Plugin
 {
 	const MAPPING_CACHE_KEY = 'SiteUrlTrackingID.Mapping';
 
-    /**
-     * Register event observers
-     *
-     * @return array
-     */
-    public function registerEvents()
-    {
-        return [
-            'Piwik.getJavascriptCode' => 'getSiteURLjs',
-            'SitesManager.getImageTrackingCode' => 'getSiteURLimg',
-            'Tracker.Request.getIdSite' => 'getSiteID',
+	/**
+	 * Register event observers
+	 *
+	 * @return array
+	 */
+	public function registerEvents()
+	{
+		return [
+			'Piwik.getJavascriptCode' => 'getSiteURLjs',
+			'SitesManager.getImageTrackingCode' => 'getSiteURLimg',
+			'Tracker.Request.getIdSite' => 'getSiteID',
 			'Tracker.setTrackerCacheGeneral'    => 'setTrackerCacheGeneral',
-        ];
-    }
+		];
+	}
 	
 	/**
 	 * Run upon activation of plugin. Clears Tracker Cache so that this plugins setTrackerCacheGeneral method will be called and added to cache
@@ -51,7 +51,7 @@ class SiteUrlTrackingID extends \Piwik\Plugin
 	{
 		TrackerCache::clearCacheGeneral();
 	}
-		
+	
 	/**
 	 * Cache all possible website urls (including aliases) for later lookup
 	 * 
@@ -61,7 +61,7 @@ class SiteUrlTrackingID extends \Piwik\Plugin
 	public function setTrackerCacheGeneral(&$cacheContent)
 	{
 		$siteUrls = new SiteUrls();
-		 
+		
 		$urls = $siteUrls->getAllCachedSiteUrls();
 		
 		$map = [];
@@ -79,34 +79,34 @@ class SiteUrlTrackingID extends \Piwik\Plugin
 		$cacheContent[self::MAPPING_CACHE_KEY] = $map;
 	}
 
-    /**
-     * Get main site URL from the site ID
-     *
-     * @param int $idSite
-     * @return string|int
-     */
-    public function getSiteURL($idSite)
-    {
+	/**
+	 * Get main site URL from the site ID
+	 *
+	 * @param int $idSite
+	 * @return string|int
+	 */
+	public function getSiteURL($idSite)
+	{
 		$siteModel = new SiteModel();
 		
 		$site = $siteModel->getSiteFromId($idSite);
-		        
-        $siteURL = $site["main_url"];
-        
-        return (!empty($siteURL) ? preg_replace('/^.+?\:\/\//i', '', $siteURL) : $idSite);
-    }
+		
+		$siteURL = $site["main_url"];
+		
+		return (!empty($siteURL) ? preg_replace('/^.+?\:\/\//i', '', $siteURL) : $idSite);
+	}
 	
-    /**
-     * Get site ID from the site URL
-     *
-     * @param int &$idSite
-     * @param array $params
-     * @return void
-     */
+	/**
+	 * Get site ID from the site URL
+	 *
+	 * @param int &$idSite
+	 * @param array $params
+	 * @return void
+	 */
 	public function getSiteID(&$idSite, $params)
-    {
-        if (!(is_int($idSite) && $idSite > 0))
-        {
+	{
+		if (!(is_int($idSite) && $idSite > 0))
+		{
 			$siteURLfull = preg_replace(['/^.+?\:\/\//','/\/\s*$/'], '', strtolower($params['idsite']));
 			
 			$siteKey = sha1($siteURLfull);
@@ -115,45 +115,45 @@ class SiteUrlTrackingID extends \Piwik\Plugin
 			
 			$idMapping = $trackerCache[self::MAPPING_CACHE_KEY];
 			
-           if(!empty($idMapping[$siteKey]))
-		   {
+			if(!empty($idMapping[$siteKey]))
+			{
 				$idSite = $idMapping[$siteKey];
-           }
-        }
-    }
+			}
+		}
+	}
 
-    /**
-     * Get site URL for the JavaScript Tracking Code
-     *
-     * @param array &$codeImpl
-     * @param array $parameters
-     * @return void
-     */
-    public function getSiteURLjs(&$codeImpl, $parameters)
-    {
+	/**
+	 * Get site URL for the JavaScript Tracking Code
+	 *
+	 * @param array &$codeImpl
+	 * @param array $parameters
+	 * @return void
+	 */
+	public function getSiteURLjs(&$codeImpl, $parameters)
+	{
 		$settings = new SystemSettings();
 		
 		if($settings->useUrlInTrackingCode->getValue())
 		{
 			$codeImpl['idSite'] = $this->getSiteURL($codeImpl['idSite']);
 		}
-    }
+	}
 
-    /**
-     * Get site URL for the Image Tracking Link
-     *
-     * @param array &$piwikUrl
-     * @param array &$urlParams
-     * @return void
-     */
-    public function getSiteURLimg(&$piwikUrl, &$urlParams)
-    {
+	/**
+	 * Get site URL for the Image Tracking Link
+	 *
+	 * @param array &$piwikUrl
+	 * @param array &$urlParams
+	 * @return void
+	 */
+	public function getSiteURLimg(&$piwikUrl, &$urlParams)
+	{
 		$settings = new SystemSettings();
 		
 		if($settings->useUrlInTrackingCode->getValue())
 		{
 			$urlParams['idsite'] = $this->getSiteURL($urlParams['idsite']);
 		}
-    }
-    
+	}
+	
 }

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SiteUrlTrackingID;
+
+use Piwik\Settings\Setting;
+use Piwik\Settings\FieldConfig;
+use Piwik\Validators\NotEmpty;
+
+class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
+{
+    /** @var Setting */
+    public $useUrlInTrackingCode;
+
+    protected function init()
+    {
+        $this->useUrlInTrackingCode = $this->createUseUrlInTrackingCodeSetting();
+    }
+
+	/**
+	 * Create ModifyTrackingCode Setting checkbox
+	 * 
+	 * @todo Desirable to this option displayed on Admin -> Websites -> Tracking Code page but I currently have no idea how to go about it. An admin option for now
+	 * 
+	 * @return SystemSetting
+	 */
+    private function createUseUrlInTrackingCodeSetting()
+    {
+        return $this->makeSetting('useUrlInTrackingCode', $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+            $field->title = 'Use URL for idSite in tracking code';
+			$field->introduction = 'Support for tracking by site URL is currently ENABLED. The following option is available to provide customization of the tracking code if desired.';
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+            $field->description = 'If enabled, the first URL of the site (as shown on the Websites > Manage screen) will be used instead of the numeric assigned id. Note: Features which rely on the tracking code, like the page overlay may fail to function.';
+        });
+    }
+}

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -14,13 +14,13 @@ use Piwik\Validators\NotEmpty;
 
 class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 {
-    /** @var Setting */
-    public $useUrlInTrackingCode;
+	/** @var Setting */
+	public $useUrlInTrackingCode;
 
-    protected function init()
-    {
-        $this->useUrlInTrackingCode = $this->createUseUrlInTrackingCodeSetting();
-    }
+	protected function init()
+	{
+		$this->useUrlInTrackingCode = $this->createUseUrlInTrackingCodeSetting();
+	}
 
 	/**
 	 * Create ModifyTrackingCode Setting checkbox
@@ -29,13 +29,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 	 * 
 	 * @return SystemSetting
 	 */
-    private function createUseUrlInTrackingCodeSetting()
-    {
-        return $this->makeSetting('useUrlInTrackingCode', $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
-            $field->title = 'Use URL for idSite in tracking code';
+	private function createUseUrlInTrackingCodeSetting()
+	{
+		return $this->makeSetting('useUrlInTrackingCode', $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+			$field->title = 'Use URL for idSite in tracking code';
 			$field->introduction = 'Support for tracking by site URL is currently ENABLED. The following option is available to provide customization of the tracking code if desired.';
-            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
-            $field->description = 'If enabled, the first URL of the site (as shown on the Websites > Manage screen) will be used instead of the numeric assigned id. Note: Features which rely on the tracking code, like the page overlay may fail to function.';
-        });
-    }
+			$field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+			$field->description = 'If enabled, the first URL of the site (as shown on the Websites > Manage screen) will be used instead of the numeric assigned id. Note: Features which rely on the tracking code, like the page overlay may fail to function.';
+		});
+	}
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,36 +1,36 @@
 {
-    "name": "SiteUrlTrackingID",
-    "description": "Enables to use any of the site URLs of a website as the tracking ID in addition to the numeric site ID.",
-    "version": "1.0.4",
-    "theme": false,
-    "require": {
-        "piwik": ">=3.3.0-stable,<4.0.0-b1",
-        "php": ">=5.4.0"
-    },
-    "authors": [
-        {
-            "name": "Kaan Erturk",
-            "email": "kaanerturk@gmail.com",
-            "homepage": "https:\/\/kaanerturk.net"
-        }
-    ],
-    "support": {
-        "email": "kaanerturk@gmail.com",
-        "issues": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID\/issues",
-        "source": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID"
-    },
-    "homepage": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID",
-    "license": "GPL v3+",
-    "keywords": [
-        "domain",
-        "domain name",
-        "site url",
-        "site id",
-        "tracking",
-        "tracking id",
-        "idsite",
-        "main_url",
-        "site_url",
-        "url"
-    ]
+	"name": "SiteUrlTrackingID",
+	"description": "Enables to use any of the site URLs of a website as the tracking ID in addition to the numeric site ID.",
+	"version": "1.0.4",
+	"theme": false,
+	"require": {
+		"piwik": ">=3.3.0-stable,<4.0.0-b1",
+		"php": ">=5.4.0"
+	},
+	"authors": [
+		{
+			"name": "Kaan Erturk",
+			"email": "kaanerturk@gmail.com",
+			"homepage": "https:\/\/kaanerturk.net"
+		}
+	],
+	"support": {
+		"email": "kaanerturk@gmail.com",
+		"issues": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID\/issues",
+		"source": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID"
+	},
+	"homepage": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID",
+	"license": "GPL v3+",
+	"keywords": [
+		"domain",
+		"domain name",
+		"site url",
+		"site id",
+		"tracking",
+		"tracking id",
+		"idsite",
+		"main_url",
+		"site_url",
+		"url"
+	]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,25 +1,36 @@
 {
     "name": "SiteUrlTrackingID",
     "description": "Enables to use any of the site URLs of a website as the tracking ID in addition to the numeric site ID.",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "theme": false,
     "require": {
-        "piwik": ">=2.15.0,<4.0.0-b1",
+        "piwik": ">=3.3.0-stable,<4.0.0-b1",
         "php": ">=5.4.0"
     },
     "authors": [
         {
             "name": "Kaan Erturk",
             "email": "kaanerturk@gmail.com",
-            "homepage": "https://kaanerturk.net"
+            "homepage": "https:\/\/kaanerturk.net"
         }
     ],
     "support": {
         "email": "kaanerturk@gmail.com",
-        "issues": "https://github.com/KaanErturk/piwik-SiteUrlTrackingID/issues",
-        "source": "https://github.com/KaanErturk/piwik-SiteUrlTrackingID"
+        "issues": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID\/issues",
+        "source": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID"
     },
-    "homepage": "https://github.com/KaanErturk/piwik-SiteUrlTrackingID",
+    "homepage": "https:\/\/github.com\/KaanErturk\/piwik-SiteUrlTrackingID",
     "license": "GPL v3+",
-    "keywords": ["domain", "domain name", "site url", "site id", "tracking", "tracking id", "idsite", "main_url", "site_url", "url"]
+    "keywords": [
+        "domain",
+        "domain name",
+        "site url",
+        "site id",
+        "tracking",
+        "tracking id",
+        "idsite",
+        "main_url",
+        "site_url",
+        "url"
+    ]
 }


### PR DESCRIPTION
Thanks for the great plugin. I just notice some areas where performance could be improved (I haven't thoroughly tested that assumption). With the tracker precache there is no longer a database call required to map URL to idSite. Also in my scenario I have a bunch of intranet sites where I am auto assigning the idSite in WordPress using the baseURL designated in WordPress. I track other non-WordPress sites using the numeric IDs so I didn't want the idSite replaced in the generated tracking code. Thus the added setting.